### PR TITLE
[ZTP] Add DHCP_L2 and DHCPV6_L2 traps registration

### DIFF
--- a/src/usr/lib/ztp/dhcp/inband-ztp-ip
+++ b/src/usr/lib/ztp/dhcp/inband-ztp-ip
@@ -18,6 +18,8 @@
 # Purpose:      Used by dhclient-script to configure IP address for front panel interface
 #
 
+export PATH=/usr/local/bin:$PATH
+
 IPprefix_by_netmask () {
     c=0 x=0$( printf '%o' $( echo $1 | sed 's/\./ /g') )
     while [ $x -gt 0 ]; do

--- a/src/usr/lib/ztp/plugins/configdb-json
+++ b/src/usr/lib/ztp/plugins/configdb-json
@@ -210,7 +210,7 @@ class ConfigDBJson:
             logger.info('configdb-json: Applying config_db.json to Config DB.')
             updateActivity('configdb-json: Applying config_db.json to Config DB')
             cmd += 'load'
-        cmd += ' -y ' + dest_file;
+        cmd += ' -f -y ' + dest_file;
         rc = runCommand(cmd, capture_stdout=False)
         if rc != 0:
             logger.error('configdb-json: Command \'%s\' failed with exit code(%d).' %(cmd, rc))

--- a/src/usr/lib/ztp/templates/ztp-config.j2
+++ b/src/usr/lib/ztp/templates/ztp-config.j2
@@ -45,5 +45,12 @@
         "product-name" : "{{PRODUCT_NAME}}",
         "serial-no" : "{{SERIAL_NO}}"
     }
-   }
+   },
+{% if ZTP_INBAND == "true" %}
+    "COPP_TRAP": {
+        "l2dhcp": {
+            "always_enabled": "true"
+        }
+    }
+{% endif %}
 }

--- a/src/usr/lib/ztp/ztp-profile.sh
+++ b/src/usr/lib/ztp/ztp-profile.sh
@@ -257,6 +257,7 @@ if [ "$CMD" = "remove" ] ; then
         else
             # Remove ZTP configuration from config-db
             sonic-db-cli CONFIG_DB DEL "ZTP|mode" > /dev/null
+            sonic-db-cli CONFIG_DB DEL "COPP_TRAP|l2dhcp" > /dev/null
         fi
 
         updateActivity "Restarting network configuration"

--- a/src/usr/lib/ztp/ztp-profile.sh
+++ b/src/usr/lib/ztp/ztp-profile.sh
@@ -221,6 +221,9 @@ if [ "$CMD" = "install" ] ; then
         # Restart interface configuration again to pickup newly created interfaces
         # to start DHCP discovery
         if [ "$(ztp status -c)" = "4:IN-PROGRESS" ]; then
+            echo "sleeping 60 seconds"
+            sleep 60
+
             echo "Restarting network configuration."
             updateActivity "Restarting network configuration"
             systemctl restart interfaces-config

--- a/src/usr/lib/ztp/ztp-profile.sh
+++ b/src/usr/lib/ztp/ztp-profile.sh
@@ -221,9 +221,6 @@ if [ "$CMD" = "install" ] ; then
         # Restart interface configuration again to pickup newly created interfaces
         # to start DHCP discovery
         if [ "$(ztp status -c)" = "4:IN-PROGRESS" ]; then
-            echo "sleeping 60 seconds"
-            sleep 60
-
             echo "Restarting network configuration."
             updateActivity "Restarting network configuration"
             systemctl restart interfaces-config


### PR DESCRIPTION
**What I did**
Add DHCP_L2 and DHCPV6_L2 traps registration.

**Why I did it**
In order to enable DHCP packets to CPU on L2 interfaces for getting IP address and DHCP ZTP options.

**How I verified it**
DHCP packets arrive to CPU and inband interface is getting IP address. In addition DHCP ZTP options are received and handled.
I also verified that traps are registered when ZTP operation starts and being deleted when ZTP finishes its operation.
